### PR TITLE
Standardise on bash for scripts, fix a few script errors.

### DIFF
--- a/share/platforms/cloudinit-nocloud
+++ b/share/platforms/cloudinit-nocloud
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # vim: set ts=4 sw=4:
 set -euo pipefail
 
@@ -81,7 +81,9 @@ cidata_get() {
 	local file="$mount_dir/$1"
 	local keypath="$2"
 
-	local query="$(echo "${keypath%/\*}" | tr '/' '\n' | xargs printf '."%s"')"
+	local query
+	query="$(echo "${keypath%/\*}" | tr '/' '\n' | xargs printf '."%s"')"
+
 	case "$keypath" in
 		*/'*') query="$query | .[]";;
 	esac

--- a/share/platforms/opennebula
+++ b/share/platforms/opennebula
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # vim: set ts=4 sw=4:
 set -euo pipefail
 

--- a/share/scripts/20-hostname
+++ b/share/scripts/20-hostname
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # vim: set ts=4 sw=4:
 set -eu
 

--- a/share/scripts/20-timezone
+++ b/share/scripts/20-timezone
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # vim: set ts=4 sw=4:
 set -euo pipefail
 

--- a/share/scripts/30-network
+++ b/share/scripts/30-network
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # vim: set ts=4 sw=4:
 set -euo pipefail
 
@@ -24,9 +24,11 @@ getvalreq() {
 # Prints network service name associated with the given MAC address, or returns
 # 1 if not found. Note that service name may contain spaces!
 find_netservice_by_mac() {
-	local mac="$(echo "$1" | tr '[A-F]' '[a-f]')"
+	local mac
+	mac="$(echo "$1" | tr '[A-F]' '[a-f]')"
 
-	local service="$(
+	local service
+	service="$(
 		networksetup -listAllNetworkServices | grep -Fv 'service is disabled.' | while read name; do
 			if networksetup -getinfo "$name" | grep -Fxq "Ethernet Address: $mac"; then
 				echo "$name"
@@ -52,7 +54,9 @@ setup_network() {
 		setup_ipv6 "$service" "$method6" "$varprefix" || rc=1
 	fi
 	if dns_srv="$(getval "${varprefix}_DNS_SERVERS")"; then
-		local dns_search="$(getval "${varprefix}_DNS_SEARCH")" ||:
+		local dns_search
+		dns_search="$(getval "${varprefix}_DNS_SEARCH")" ||:
+
 		setup_dns "$service" "$dns_srv" "$dns_search" || rc=1
 	fi
 

--- a/share/scripts/50-admin-user
+++ b/share/scripts/50-admin-user
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # vim: set ts=4 sw=4:
 set -eu
 

--- a/share/scripts/55-ssh-keys
+++ b/share/scripts/55-ssh-keys
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # vim: set ts=4 sw=4:
 set -eu
 
@@ -14,7 +14,8 @@ update_ssh_keys() {
 	homedir="${homedir#*: }"  # strip 'FSHomeDirectory: '
 
 	local auth_file="$homedir/.ssh/authorized_keys"
-	local group="$(id -gn "$user")"
+	local group
+	group="$(id -gn "$user")"
 
 	if ! [ -f "$auth_file" ]; then
 		install -m700 -o "$user" -g "$group" -d "${auth_file%/*}"

--- a/share/scripts/80-grow-fs
+++ b/share/scripts/80-grow-fs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # vim: set ts=4 sw=4:
 set -euo pipefail
 
@@ -32,7 +32,7 @@ fs_resize_if_needed() {
 	max_size="$(apfs_cntr_limits "$part_dev" MaximumSize)"
 
 	if [ "$max_size" -ne "$cur_size" ]; then
-		echo "Resizing $cntr_dev on $phy_dev from $(b2gb $cur_size) to $(b2gb $max_size) GiB" >&2
+		echo "Resizing $cntr_dev on $phy_dev from $(b2gb "$cur_size") to $(b2gb "$max_size") GiB" >&2
 
 		echo yes | diskutil repairDisk "$phy_dev"
 		diskutil apfs resizeContainer "/dev/$cntr_dev" 0
@@ -42,7 +42,7 @@ fs_resize_if_needed() {
 
 if [ "$(fs_type '/')" != 'apfs' ]; then
 	echo "WARN: Filesystem $(fs_type '/') is not supported, skipping grow-fs" >&2
-	return 0
+	exit 0
 fi
 
 fs_resize_if_needed '/'


### PR DESCRIPTION
The main macos-init script already depends explicitly on bash and most of the others make use of bash features (e.g. local), so just use bash for all scripts.