### PR TITLE
Wait up to 10 seconds for cloud-init disk to mount.

### DIFF
--- a/share/platforms/cloudinit-nocloud
+++ b/share/platforms/cloudinit-nocloud
@@ -27,7 +27,7 @@ ready() {
 }
 
 read_params() {
-	mount_volume "$cloudinit_volume_label" \
+	wait_for 10 mount_volume "$cloudinit_volume_label" \
 		|| die "Failed to mount volume $cloudinit_volume_label"
 	check_cidata
 


### PR DESCRIPTION
From the looks of the code here, the ready call is intended to defer activation of the platform script until the disk is present, however this seems to fail on some versions of macOS due to the ISO appearing and then disappearing before stabilising at boot.