### PR TITLE
Don't mount the context disk - rely on automount.

### DIFF
--- a/share/platforms/cloudinit-nocloud
+++ b/share/platforms/cloudinit-nocloud
@@ -23,12 +23,10 @@ mount_dir="/Volumes/$cloudinit_volume_label"
 command -v yq >/dev/null || die "yq was not found; install it using 'brew install yq'"
 
 ready() {
-	diskutil list physical "$cloudinit_volume_label" >/dev/null
+	_ismountpoint "${mount_dir}" && [ "$(echo "${mount_dir}"/*)" != "${mount_dir}/*" ]
 }
 
 read_params() {
-	mount_volume "$cloudinit_volume_label" \
-		|| die "Failed to mount volume $cloudinit_volume_label"
 	check_cidata
 
 	set -f  # disable globbing
@@ -46,8 +44,6 @@ read_params() {
 			printf "export %s='%s'\n" "$var" "$(escape_squote "$val")"
 		fi
 	done
-
-	diskutil umount "$cloudinit_volume_label" >/dev/null
 }
 
 check_cidata() {

--- a/share/platforms/opennebula
+++ b/share/platforms/opennebula
@@ -27,12 +27,10 @@ mount_dir="/Volumes/$opennebula_volume_label"
 
 
 ready() {
-	diskutil list physical "$opennebula_volume_label" >/dev/null
+	_ismountpoint "${mount_dir}" && [ "$(echo "${mount_dir}"/*)" != "${mount_dir}/*" ]
 }
 
 read_params() {
-	mount_volume "$opennebula_volume_label" \
-		|| die "Failed to mount volume $opennebula_volume_label"
 	check_context
 
 	set -f  # disable globbing
@@ -52,8 +50,6 @@ read_params() {
 		)" >/dev/null
 		printf "export %s='%s'\n" "$var" "$(escape_squote "$val")"
 	done
-
-	diskutil umount "$opennebula_volume_label" >/dev/null
 }
 
 check_context() {


### PR DESCRIPTION
The default behaviour of macOS is to automatically mount any detected disks and trying to explicitly mount the context disk ourselves seems to cause different race conditions and general weirdness depending on the version of macOS in use.